### PR TITLE
feat : modal 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "tailwind-styled-components": "^2.2.0",
         "tailwindcss": "^3.3.2"
       }
     },
@@ -16415,6 +16416,29 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "node_modules/tailwind-merge": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.12.0.tgz",
+      "integrity": "sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwind-styled-components": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tailwind-styled-components/-/tailwind-styled-components-2.2.0.tgz",
+      "integrity": "sha512-Ogemwk0p69aU8WE/ooJZHjqstdJgT5R6HGU6TFz2uSnveSEtvW+C6aWOjGCvCr5H/bREv0IbbQ4yODknRrLBRQ==",
+      "dev": true,
+      "dependencies": {
+        "tailwind-merge": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "tailwind-styled-components": "^2.2.0",
     "tailwindcss": "^3.3.2"
   }
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,1 +1,80 @@
-export default function Modal() {}
+import * as React from "react";
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
+import Fade from "@mui/material/Fade";
+import OpenWithIcon from "@mui/icons-material/OpenWith";
+import StarIcon from "@mui/icons-material/Star";
+import CloseIcon from "@mui/icons-material/Close";
+
+export default function TransitionsModal({
+  imgSelector,
+  titleSelector,
+  onClickBookMark,
+  isBookMarked,
+}) {
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div className="absolute m-2 cursor-pointer">
+      <OpenWithIcon
+        onClick={handleOpen}
+        sx={{ color: "white", fontSize: 40, opacity: 0.5 }}
+      />
+      <Modal
+        aria-labelledby="transition-modal-title"
+        aria-describedby="transition-modal-description"
+        open={open}
+        onClose={handleClose}
+        closeAfterTransition
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 500,
+          },
+        }}
+      >
+        <Fade in={open}>
+          <Box sx={style}>
+            <CloseIcon
+              className="absolute top-5 right-5 cursor-pointer"
+              sx={{ color: "white", fontSize: 40 }}
+              onClick={handleClose}
+            />
+            <div className="flex items-center absolute bottom-5 left-5 text-white text-2xl cursor-default font-bold">
+              {titleSelector}
+
+              <StarIcon
+                onClick={() => {
+                  onClickBookMark();
+                }}
+                className="drop-shadow-lg cursor-pointer"
+                sx={{
+                  color: isBookMarked ? "#FFD361" : "#DFDFDF",
+                  fontSize: 40,
+                }}
+              />
+            </div>
+
+            <img className="p-0 w-full h-full" src={imgSelector} alt="이미지" />
+          </Box>
+        </Fade>
+      </Modal>
+    </div>
+  );
+}
+
+const style = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 744,
+  height: 480,
+  bgcolor: "background.paper",
+  boxShadow: 24,
+  p: 4,
+  padding: 0,
+};

--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -1,4 +1,5 @@
 import StarIcon from "@mui/icons-material/Star";
+import TransitionsModal from "./Modal";
 
 export function getIsBookMarked(bookMarkedIdList, id) {
   return bookMarkedIdList.includes(id);
@@ -20,20 +21,43 @@ export default function ProductCard({ data, isBookMarked, onClickBookMark }) {
   const imgUrl = data.image_url;
   const brandImgUrl = data.brand_image_url;
 
+  const imgSelector = () => {
+    if (brandImgUrl) {
+      return brandImgUrl;
+    } else {
+      return imgUrl;
+    }
+  };
+
+  const titleSelector = () => {
+    if (data.title) {
+      return data.title;
+    } else {
+      return data.brand_name;
+    }
+  };
+
   return (
-    <div className="flex relative flex-col w-264 h-264">
+    <div className="flex relative flex-col w-264 h-264 cursor-default">
+      <TransitionsModal
+        imgSelector={imgSelector()}
+        titleSelector={titleSelector()}
+        onClickBookMark={onClickBookMark}
+        isBookMarked={isBookMarked}
+      />
       <div className="h-4/5">
         <img
           className="h-full w-full rounded-lg"
-          src={brandImgUrl ? brandImgUrl : imgUrl}
+          src={imgSelector()}
           alt="상품이미지"
         />
+
         <div className="absolute bottom-14 right-2">
           <StarIcon
             onClick={() => {
               onClickBookMark();
             }}
-            className="drop-shadow-lg"
+            className="drop-shadow-lg cursor-pointer"
             sx={{
               color: isBookMarked ? "#FFD361" : "#DFDFDF",
               fontSize: 40,


### PR DESCRIPTION
1. modal 이 열리게 구현했습니다

2. 상품카드 내부에서 모달 컴포넌트를 넣어서 필요한 데이터들을 props로 넘겨줬습니다.

3. 전역 상태 관리 라이브러리를 사용하지않아서 코드가 좀 지저분할수있습니다. 이번 목표는 전역 상태 관리 라이브러리를 사용하지않고 구현해보는것이 목표입니다. 추후에 리팩토링을 거치면서 리덕스를 사용해보면 실력이 향상될거같다는 확신이 섰습니다.

4. 그 다음 목표는 무한 스크롤입니다.